### PR TITLE
Make loading .env files opt in

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ hooks into a change in PWD to automatically launch a [Poetry](https://python-poe
 ## Installation
 
 
-|manager|command|
-|---|---|
-|[fisher](https://github.com/jorgebucaran/fisher)|`fisher install 'ryoppippi/fish-poetry'`|
+| manager                                          | command                                  |
+| ------------------------------------------------ | ---------------------------------------- |
+| [fisher](https://github.com/jorgebucaran/fisher) | `fisher install 'ryoppippi/fish-poetry'` |
 
+## Options
+Optionally you can load environment variables from a `.env` file. To do so you must `set FISH_POETRY_LOAD_ENV true`

--- a/conf.d/fish-poetry.fish
+++ b/conf.d/fish-poetry.fish
@@ -28,7 +28,7 @@ if command -s poetry > /dev/null
         if not test -n "$POETRY_ACTIVE"
           if poetry env info -p >/dev/null 2>&1
             set -x __poetry_fish_initial_pwd "$PWD"
-            if test -e "$PWD/.env"
+            if test "$FISH_POETRY_LOAD_ENV" -a -e "$PWD/.env"
                 echo "Setting environment variables..."
                 posix-source $PWD/.env
             end


### PR DESCRIPTION
With this PR loading `.env` files will require explicit opt in by setting `FISH_POETRY_LOAD_ENV=true` Fixes #4 