### PR TITLE
Check for poetry project on startup

### DIFF
--- a/conf.d/fish-poetry.fish
+++ b/conf.d/fish-poetry.fish
@@ -26,21 +26,21 @@ if command -s poetry > /dev/null
         end
 
         if not test -n "$POETRY_ACTIVE"
-          if poetry env info -p >/dev/null 2>&1
-            set -x __poetry_fish_initial_pwd "$PWD"
-            if test "$FISH_POETRY_LOAD_ENV" -a -e "$PWD/.env"
-                echo "Setting environment variables..."
-                posix-source $PWD/.env
-            end
+            if poetry env info -p >/dev/null 2>&1
+                set -x __poetry_fish_initial_pwd "$PWD"
+                if test "$FISH_POETRY_LOAD_ENV" -a -e "$PWD/.env"
+                    echo "Setting environment variables..."
+                    posix-source $PWD/.env
+                end
 
-            poetry shell
+                poetry shell
 
-            set -e __poetry_fish_initial_pwd
-            if test -n "$__poetry_fish_final_pwd"
-                cd "$__poetry_fish_final_pwd"
-                set -e __poetry_fish_final_pwd
+                set -e __poetry_fish_initial_pwd
+                if test -n "$__poetry_fish_final_pwd"
+                    cd "$__poetry_fish_final_pwd"
+                    set -e __poetry_fish_final_pwd
+                end
             end
-          end
         end
     end
 else

--- a/conf.d/fish-poetry.fish
+++ b/conf.d/fish-poetry.fish
@@ -12,7 +12,6 @@ if command -s poetry > /dev/null
         end
     end
 
-
     function __poetry_shell_activate --on-variable PWD
         if status --is-command-substitution
             return
@@ -43,6 +42,9 @@ if command -s poetry > /dev/null
             end
         end
     end
+
+    # Check if this shell was started in a directory that has a poetry project and directly activate it
+    __poetry_shell_activate
 else
     function poetry -d "https://python-poetry.org"
         echo "Install https://python-poetry.org to use this plugin." > /dev/stderr


### PR DESCRIPTION
(also includes some formatting fixes for inconsistent indentation, I can put that in a separate PR)

Adds a call to `__poetry_shell_activate` on startup so that the poetry project is enabled when spawning the shell (for example when using the "Duplicate shell" feature of iTerm which spawns a new shell in the same cwd as a previous one)